### PR TITLE
Bug Fix in SignedIn intent handler

### DIFF
--- a/functions/config/intent-constants.js
+++ b/functions/config/intent-constants.js
@@ -156,7 +156,7 @@ module.exports = {
   },
   PROBLEM_LOGIN_INTENT: {
     intent: 'problem.login.intent',
-    event: 'PROBLEM_LOGIN_INTENT_HANDLER',
+    event: 'PROBLEM_LOGIN_INTENT_EVENT',
     handler: 'problemLoginHandler'
   }
 };


### PR DESCRIPTION
handle account linking cancelled event. to notify user enabling personal results if it's turned off by default. and to clear any intent prefix content in problem related intent